### PR TITLE
You don't need sudo for everything, and path cleanup

### DIFF
--- a/module_linux.py
+++ b/module_linux.py
@@ -347,7 +347,7 @@ class GetLinuxData():
             self.allData.append(macData)
 
     def get_hdd(self):
-        cmd = 'fdisk -l | grep "Disk /dev"'
+        cmd = '/sbin/fdisk -l | grep "Disk /dev"'
         data_out,data_err = self.execute(cmd)
         errhdds = []
         if data_err:

--- a/module_linux.py
+++ b/module_linux.py
@@ -129,7 +129,7 @@ class GetLinuxData():
     def get_system(self):
         self.device_name = self.get_name()
         if self.device_name not in ('', None):
-            cmd = '$(which dmidecode) -t system'
+            cmd = '/usr/sbin/dmidecode -t system'
             data_out,data_err = self.execute(cmd, True)
             if not data_err:
                 dev_type = None
@@ -269,7 +269,7 @@ class GetLinuxData():
                 print '\t[-] Could not get CPU info from host %s. Message was: %s' % (self.machine_name, str(data_err))
 
     def get_IP(self):
-        cmd = 'ifconfig'
+        cmd = '/sbin/ifconfig'
         data_out,data_err = self.execute(cmd)
         if not data_err:
             NEW = True

--- a/module_linux.py
+++ b/module_linux.py
@@ -126,7 +126,7 @@ class GetLinuxData():
     def get_system(self):
         self.device_name = self.get_name()
         if self.device_name not in ('', None):
-            cmd = 'dmidecode -t system'
+            cmd = '$(which dmidecode) -t system'
             data_out,data_err = self.execute(cmd)
             if not data_err:
                 dev_type = None


### PR DESCRIPTION
Two things are handled by this set of commits: 

1. You don't need to sudo every command, and this causes errors when you have only allowed dmidecode in your sudoers file. Instead of chasing the addition of all of those commands add a check that defaults to False for sudo needed. Pass in true for the dmidecode command
2. You cannot rely on /usr/sbin and /sbin being in the users path. Fully qualify the paths to the utilities that live in /sbin or /usr/sbin