### PR TITLE
fix dladm breaking on SPARC Enterprise M4000

### DIFF
--- a/module_solaris.py
+++ b/module_solaris.py
@@ -105,12 +105,16 @@ class GetSolarisData:
         data_err = stderr.readlines()
         if not data_err:
             for rec in data_out[1:]:
-                nic, slot, address, in_use, client = rec.split()
-                # dladm returns MACs in wrong format
-                if address:
-                    raw = address.split(':')
-                    address = ':'.join([x if len(x) == 2 else ('0' + x) for x in raw])
-                macs.update({nic: address})
+                #make sure that we only get macs that have been assigned to an interface otherwise rec.split will fail
+                if not rec.startswith(' '):
+                    nic, slot, address, in_use, client = rec.split()
+                    # dladm returns MACs in wrong format
+                    if address:
+                        raw = address.split(':')
+                        address = ':'.join([x if len(x) == 2 else ('0' + x) for x in raw])
+                    #filter out the column description if it appears again
+                    if nic != "LINK":
+                        macs.update({nic: address})
             return macs
         else:
             stdin, stdout, stderr = self.ssh.exec_command("/usr/sbin/arp -a")


### PR DESCRIPTION
It is possible for not all MAC Addresses in the system to be assigned to an interface so rec.split() will fail resulting in the message "need more than 4 values to unpack" because there is no NIC in the output.  

Also, since there were so many MAC addresses on the system, the column descriptions printed multiple times in the output so need to filter those out as well.