### PR TITLE
Update inventory.cfg.sample

### DIFF
--- a/inventory.cfg.sample
+++ b/inventory.cfg.sample
@@ -55,11 +55,11 @@ ignore_virtual_machines		= False
 upload_ipv6        			= True
 duplicate_serials  			= False
 remove_stale_ips			= True
-add_hdd_as_device_properties= False # Device properties doesn't handle asymmetrical disk configs well. Better handled in parts.
-add_hdd_as_parts			= True
 give_hostname_precedence	= True
 mac_lookup					= False
 debug              			= True
 threads            			= 50
 dict_output        			= False
-
+#Device properties doesn't handle asymmetrical disk configs well. Better handled in parts.
+add_hdd_as_device_properties= False 
+add_hdd_as_parts			= True


### PR DESCRIPTION
Better commenting of line, also fixes bug:
Traceback (most recent call last): 
File "main.py", line 423, in <module> 
from module_shared import * 
File "/root/nix_bsd_mac_inventory/module_shared.py", line 73, in <module> 
REMOVE_STALE_IPS = get_settings() 
File "/root/nix_bsd_mac_inventory/module_shared.py", line 50, in get_settings 
add_hdd_as_device_properties = cc.getboolean('options', 'add_hdd_as_device_properties') 
File "/usr/lib/python2.7/ConfigParser.py", line 370, in getboolean 
raise ValueError, 'Not a boolean: %s' % v 
ValueError: Not a boolean: False # Device properties doesn't handle asymmetrical disk configs well. Better handled in parts.