### PR TITLE
Don't remove IPMI Auto-Discovery created IPs

### DIFF
--- a/util_uploader.py
+++ b/util_uploader.py
@@ -122,7 +122,7 @@ class Rest:
                 print msg
             response = self.fetcher(url)
             if isinstance(response, dict) and 'ip_addresses' in response:
-                fetched_ips = [x['ip'] for x in response['ip_addresses'] if 'ip' in x]
+                fetched_ips = [x['ip'] for x in response['ip_addresses'] if 'ip' in x and x['label'] != 'mgmt']
                 return fetched_ips
 
     def delete_ip(self, ip):


### PR DESCRIPTION
When using `remove_stale_ips=True`, IP addresses that were created by IPMI Auto-Discovery and labeled as `mgmt` would be removed since this script will not find them to be physical interfaces on the device being scanned.  Change `get_device_by_name()` to not return interfaces so labeled.